### PR TITLE
Adds README documenting where streamlit gets declared for nightly-preview app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+To whom it may concern, if you're looking at the requirements.txt on the master branch, and are scratching your head wondering where streamlit gets defined for the nightly-preview app, it's because the entry for streamlit gets added by an automation and only to the nightly-preview branch. Switch to that branch, and you should see it!


### PR DESCRIPTION
Adds README.md telling people to look at the `nightly-preview` branch when searching for where `streamlit` gets declared